### PR TITLE
Padding and truncation

### DIFF
--- a/lib/tokenizers.ex
+++ b/lib/tokenizers.ex
@@ -89,7 +89,28 @@ defmodule Tokenizers do
 
   @doc """
   Truncate the encoding.
+  @doc """
+  Pad the encoding to the given length.
+
+  ## Options
+    * `direction` - The padding direction. Can be `:right` or `:left`. Default: `:right`.
+    * `pad_id` - The id corresponding to the padding token. Default: `0`.
+    * `pad_token` - The padding token to use. Default: `"[PAD]"`.
+    * `pad_type_id` - The type ID corresponding to the padding token. Default: `0`.
   """
-  @spec truncate(Encoding.t(), integer(), integer()) :: {:ok, Encoding.t()} | {:error, term()}
-  def truncate(encoding, max_len, stride), do: Native.truncate(encoding, max_len, stride)
+  @spec pad(encoding :: Encoding.t(), length :: pos_integer(), opts :: Keyword.t()) ::
+          Encoding.t()
+  def pad(encoding, length, opts \\ []) do
+    opts =
+      Keyword.validate!(opts, direction: :right, pad_id: 0, pad_type_id: 0, pad_token: "[PAD]")
+
+    Native.pad(
+      encoding,
+      length,
+      opts[:pad_id],
+      opts[:pad_type_id],
+      opts[:pad_token],
+      "#{opts[:direction]}"
+    )
+  end
 end

--- a/lib/tokenizers.ex
+++ b/lib/tokenizers.ex
@@ -88,7 +88,19 @@ defmodule Tokenizers do
   def token_to_id(tokenizer, token), do: Native.token_to_id(tokenizer, token)
 
   @doc """
-  Truncate the encoding.
+  Truncate the encoding to the given length.
+
+  ## Options
+    * `direction` - The truncation direction. Can be `:right` or `:left`. Default: `:right`.
+    * `stride` - The length of previous content to be included in each overflowing piece. Default: `0`.
+  """
+  @spec truncate(encoding :: Encoding.t(), length :: integer(), opts :: Keyword.t()) ::
+          {:ok, Encoding.t()} | {:error, term()}
+  def truncate(encoding, max_len, opts \\ []) do
+    opts = Keyword.validate!(opts, direction: :right, stride: 0)
+    Native.truncate(encoding, max_len, opts[:stride], "#{opts[:direction]}")
+  end
+
   @doc """
   Pad the encoding to the given length.
 

--- a/lib/tokenizers/native.ex
+++ b/lib/tokenizers/native.ex
@@ -17,7 +17,7 @@ defmodule Tokenizers.Native do
   def id_to_token(_tokenizer, _id), do: err()
   def save(_tokenizer, _path, _pretty), do: err()
   def token_to_id(_tokenizer, _token), do: err()
-  def truncate(_encoding, _max_len, _stride), do: err()
+  def truncate(_encoding, _max_len, _stride, _direction), do: err()
   def pad(_encoding, _target_length, _pad_id, _pad_type_id, _pad_token, _direction), do: err()
 
   defp err(), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/tokenizers/native.ex
+++ b/lib/tokenizers/native.ex
@@ -18,6 +18,7 @@ defmodule Tokenizers.Native do
   def save(_tokenizer, _path, _pretty), do: err()
   def token_to_id(_tokenizer, _token), do: err()
   def truncate(_encoding, _max_len, _stride), do: err()
+  def pad(_encoding, _target_length, _pad_id, _pad_type_id, _pad_token, _direction), do: err()
 
   defp err(), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/ex_tokenizers/Cargo.lock
+++ b/native/ex_tokenizers/Cargo.lock
@@ -807,6 +807,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641c64af6cd80b81cf9c2f2f6ee382b1050c71ce63e20800499971a4a4195005"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb246ada5a8c47b8b6e90c9f9a0f84f294939cdf558f1bc8d17fbb30f9706598"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1002,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "percent-encoding"
@@ -1533,10 +1554,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokenizers"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c159c4c2efb7d3fbed139b726cb5c0135b12d68e2c09afc1a851f8f2534e8"
+checksum = "60c79b46b9e4a7c8a4926531d1b81521a976cab19f1651627385504aa68799f2"
 dependencies = [
+ "aho-corasick",
  "cached-path",
  "clap",
  "derive_builder",
@@ -1546,7 +1568,9 @@ dependencies = [
  "itertools 0.9.0",
  "lazy_static",
  "log",
+ "macro_rules_attribute",
  "onig",
+ "paste",
  "rand 0.7.3",
  "rayon",
  "rayon-cond",

--- a/native/ex_tokenizers/Cargo.toml
+++ b/native/ex_tokenizers/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 anyhow = "1"
 rustler = "0.23.0"
 thiserror = "1"
-tokenizers = "0.11.0"
+tokenizers = "0.11.3"

--- a/native/ex_tokenizers/src/encoding.rs
+++ b/native/ex_tokenizers/src/encoding.rs
@@ -1,4 +1,6 @@
 use crate::error::ExTokenizersError;
+use tokenizers::utils::padding::PaddingDirection;
+use tokenizers::utils::truncation::TruncationDirection;
 use tokenizers::Encoding;
 
 pub struct ExTokenizersEncodingRef(pub Encoding);
@@ -43,9 +45,17 @@ pub fn truncate(
     encoding: ExTokenizersEncoding,
     max_len: usize,
     stride: usize,
+    direction: &str,
 ) -> Result<ExTokenizersEncoding, ExTokenizersError> {
+    let direction: TruncationDirection = match direction {
+        "left" => TruncationDirection::Left,
+        "right" => TruncationDirection::Right,
+        _ => panic!("direction must be right or left"),
+    };
     let mut new_encoding = encoding.resource.0.clone();
-    new_encoding.truncate(max_len, stride);
+    new_encoding.truncate(max_len, stride, direction);
+    Ok(ExTokenizersEncoding::new(new_encoding))
+}
 
 #[rustler::nif]
 pub fn pad(

--- a/native/ex_tokenizers/src/encoding.rs
+++ b/native/ex_tokenizers/src/encoding.rs
@@ -46,5 +46,22 @@ pub fn truncate(
 ) -> Result<ExTokenizersEncoding, ExTokenizersError> {
     let mut new_encoding = encoding.resource.0.clone();
     new_encoding.truncate(max_len, stride);
+
+#[rustler::nif]
+pub fn pad(
+    encoding: ExTokenizersEncoding,
+    target_length: usize,
+    pad_id: u32,
+    pad_type_id: u32,
+    pad_token: &str,
+    direction: &str,
+) -> Result<ExTokenizersEncoding, ExTokenizersError> {
+    let direction: PaddingDirection = match direction {
+        "left" => PaddingDirection::Left,
+        "right" => PaddingDirection::Right,
+        _ => panic!("direction must be right or left"),
+    };
+    let mut new_encoding = encoding.resource.0.clone();
+    new_encoding.pad(target_length, pad_id, pad_type_id, pad_token, direction);
     Ok(ExTokenizersEncoding::new(new_encoding))
 }

--- a/native/ex_tokenizers/src/lib.rs
+++ b/native/ex_tokenizers/src/lib.rs
@@ -29,6 +29,7 @@ rustler::init!(
         get_vocab,
         get_vocab_size,
         id_to_token,
+        pad,
         save,
         token_to_id,
         truncate

--- a/notebooks/pretrained.livemd
+++ b/notebooks/pretrained.livemd
@@ -5,7 +5,8 @@
 ```elixir
 Mix.install([
   {:kino, "~> 0.5.2"},
-  {:tokenizers, path: "../"}
+  {:scidata, "~> 0.1.5"},
+  {:tokenizers, path: "./"}
 ])
 ```
 
@@ -88,4 +89,41 @@ list_of_ids =
 
 ```elixir
 Tokenizers.decode(tokenizer, list_of_ids)
+```
+
+## Get a tensor
+
+In order to get a tensor, we need sequences that are all of the same length. We'll get some data from `Scidata` and use `Tokenizers.pad/3` and `Tokenizers.truncate/3` to yield a tensor.
+
+```elixir
+%{review: reviews} = Scidata.YelpPolarityReviews.download_test()
+```
+
+```elixir
+tensor =
+  reviews
+  |> Enum.take(10)
+  |> Enum.map(fn review ->
+    {:ok, tokenized} = Tokenizers.encode(tokenizer, review)
+    {:ok, padded} = Tokenizers.pad(tokenized, 200)
+    {:ok, truncated} = Tokenizers.truncate(padded, 200, [])
+    {:ok, indices} = Tokenizers.get_ids(truncated)
+    indices
+  end)
+  |> Nx.tensor()
+```
+
+And we can reverse the operation to see our data. Note the `[PAD]` tokens.
+
+```elixir
+tensor
+|> Nx.to_batched_list(1)
+|> Enum.map(fn tensor_review ->
+  {:ok, decoded} =
+    tensor_review
+    |> Nx.to_flat_list()
+    |> then(&Tokenizers.decode(tokenizer, &1))
+
+  decoded
+end)
 ```


### PR DESCRIPTION
This adds the ability to pad and truncate encodings. We had truncation before, but it's more complete with version `0.11.3` of :hugs: Tokenizers as you can now specify the direction. I've bumped the version accordingly.

@seanmor5 this should be all that's needed for basic use with Axon. I'm working on a text classifier example for Axon using Scidata's yelp polarity dataset. LMK if you think something else might be more reasonable.

Added an example to the introductory Livebook illustrating how this might look.