### PR TITLE
Add skip/add special token option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ tokenizers-*.tar
 
 # Shared objects build by Rust.
 *.so
+
+.nix-*

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,9 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachSystem [
       flake-utils.lib.system.x86_64-linux
-      flake-utils.lib.system.aarch64-darwin
       flake-utils.lib.system.x86_64-darwin
+      flake-utils.lib.system.aarch64-darwin
+      flake-utils.lib.system.aarch64-linux
     ]
       (system:
         let pkgs = import nixpkgs { inherit system; };

--- a/lib/tokenizers/tokenizer.ex
+++ b/lib/tokenizers/tokenizer.ex
@@ -57,10 +57,10 @@ defmodule Tokenizers.Tokenizer do
     do_decode(tokenizer, ids, skip_special_tokens)
   end
 
-  def do_decode(tokenizer, [first | _] = ids, skip_special_tokens) when is_integer(first),
+  defp do_decode(tokenizer, [first | _] = ids, skip_special_tokens) when is_integer(first),
     do: Native.decode(tokenizer, ids, skip_special_tokens)
 
-  def do_decode(tokenizer, [first | _] = ids, skip_special_tokens) when is_list(first),
+  defp do_decode(tokenizer, [first | _] = ids, skip_special_tokens) when is_list(first),
     do: Native.decode_batch(tokenizer, ids, skip_special_tokens)
 
   @doc """

--- a/lib/tokenizers/tokenizer.ex
+++ b/lib/tokenizers/tokenizer.ex
@@ -32,23 +32,36 @@ defmodule Tokenizers.Tokenizer do
   @doc """
   Encode the given sequence or batch of sequences to a `Tokenizers.Encoding.t()`.
   """
-  @spec encode(Tokenizer.t(), String.t() | [String.t()]) ::
+  @spec encode(Tokenizer.t(), String.t() | [String.t()], Keyword.t()) ::
           {:ok, Encoding.t() | [Encoding.t()]} | {:error, term()}
-  def encode(tokenizer, input) when is_binary(input), do: Native.encode(tokenizer, input, false)
+  def encode(tokenizer, input, opts \\ []) do
+    add_special_tokens = Keyword.get(opts, :add_special_tokens, false)
+    do_encode(tokenizer, input, add_special_tokens)
+  end
 
-  def encode(tokenizer, input) when is_list(input),
-    do: Native.encode_batch(tokenizer, input, false)
+  defp do_encode(tokenizer, input, add_special_tokens) when is_binary(input) do
+    Native.encode(tokenizer, input, add_special_tokens)
+  end
+
+  defp do_encode(tokenizer, input, add_special_tokens) when is_list(input) do
+    Native.encode_batch(tokenizer, input, add_special_tokens)
+  end
 
   @doc """
   Decode the given list of ids or list of lists of ids back to strings.
   """
-  @spec decode(Tokenizer.t(), non_neg_integer() | [non_neg_integer()]) ::
+  @spec decode(Tokenizer.t(), non_neg_integer() | [non_neg_integer()], Keyword.t()) ::
           {:ok, String.t() | [String.t()]} | {:error, term()}
-  def decode(tokenizer, [first | _] = ids) when is_integer(first),
-    do: Native.decode(tokenizer, ids, false)
+  def decode(tokenizer, ids, opts \\ []) do
+    skip_special_tokens = Keyword.get(opts, :skip_special_tokens, false)
+    do_decode(tokenizer, ids, skip_special_tokens)
+  end
 
-  def decode(tokenizer, [first | _] = ids) when is_list(first),
-    do: Native.decode_batch(tokenizer, ids, false)
+  def do_decode(tokenizer, [first | _] = ids, skip_special_tokens) when is_integer(first),
+    do: Native.decode(tokenizer, ids, skip_special_tokens)
+
+  def do_decode(tokenizer, [first | _] = ids, skip_special_tokens) when is_list(first),
+    do: Native.decode_batch(tokenizer, ids, skip_special_tokens)
 
   @doc """
   Get the tokenizer's vocabulary as a map of token to id.

--- a/test/tokenizers/tokenizer_test.exs
+++ b/test/tokenizers/tokenizer_test.exs
@@ -30,6 +30,14 @@ defmodule Tokenizers.TokenizerTest do
       assert match?({:ok, %Tokenizers.Encoding{}}, Tokenizer.encode(tokenizer, "This is a test"))
     end
 
+    test "can encode a single string with special characters", %{tokenizer: tokenizer} do
+      seq = "This is a test"
+      {:ok, encoding_clean} = Tokenizer.encode(tokenizer, seq)
+      {:ok, encoding_special} = Tokenizer.encode(tokenizer, seq, add_special_tokens: true)
+
+      refute Encoding.n_tokens(encoding_clean) == Encoding.n_tokens(encoding_special)
+    end
+
     test "can encode a batch of strings", %{tokenizer: tokenizer} do
       assert match?(
                {:ok, [%Tokenizers.Encoding{} | _]},
@@ -43,6 +51,18 @@ defmodule Tokenizers.TokenizerTest do
       ids = Encoding.get_ids(encoding)
       {:ok, decoded} = Tokenizer.decode(tokenizer, ids)
       assert decoded == text
+    end
+
+    test "can decode a single encoding skipping special characters", %{tokenizer: tokenizer} do
+      seq = "This is a test"
+      {:ok, encoding} = Tokenizer.encode(tokenizer, seq, add_special_tokens: true)
+      ids = Encoding.get_ids(encoding)
+
+      {:ok, seq_clean} = Tokenizer.decode(tokenizer, ids, skip_special_tokens: true)
+      {:ok, seq_special} = Tokenizer.decode(tokenizer, ids)
+
+      refute seq_special == seq
+      assert seq_clean == seq
     end
 
     test "can decode a batch of encodings", %{tokenizer: tokenizer} do


### PR DESCRIPTION
Let tokenizer take care of special tokens (e.g. `[CLS]`, `[SEP]` for BERT) as an encode/decode option. Right now it is hardcoded to ignore special characters completely.