### PR TITLE
Add support for encoding sequence pairs

### DIFF
--- a/lib/tokenizers/encoding.ex
+++ b/lib/tokenizers/encoding.ex
@@ -24,10 +24,16 @@ defmodule Tokenizers.Encoding do
   def get_ids(encoding), do: encoding |> Native.get_ids() |> Shared.unwrap()
 
   @doc """
-  Get the attention_mask from an encoding.
+  Get the attention mask from an encoding.
   """
   @spec get_attention_mask(Encoding.t()) :: [integer()]
   def get_attention_mask(encoding), do: encoding |> Native.get_attention_mask() |> Shared.unwrap()
+
+  @doc """
+  Get token type ids from an encoding.
+  """
+  @spec get_type_ids(Encoding.t()) :: [integer()]
+  def get_type_ids(encoding), do: encoding |> Native.get_type_ids() |> Shared.unwrap()
 
   @doc """
   Truncate the encoding to the given length.

--- a/lib/tokenizers/native.ex
+++ b/lib/tokenizers/native.ex
@@ -17,6 +17,7 @@ defmodule Tokenizers.Native do
   def from_file(_path), do: err()
   def from_pretrained(_identifier), do: err()
   def get_attention_mask(_encoding), do: err()
+  def get_type_ids(_encoding), do: err()
   def get_ids(_encoding), do: err()
   def get_tokens(_encoding), do: err()
   def get_vocab(_tokenizer, _with_added_tokens), do: err()

--- a/lib/tokenizers/tokenizer.ex
+++ b/lib/tokenizers/tokenizer.ex
@@ -21,6 +21,13 @@ defmodule Tokenizers.Tokenizer do
   alias Tokenizers.Native
   alias Tokenizers.Shared
 
+  @typedoc """
+  An input being a subject to tokenization.
+
+  Can be either a single sequence, or a pair of sequences.
+  """
+  @type encode_input :: String.t() | {String.t(), String.t()}
+
   @doc """
   Instantiate a new tokenizer from an existing file on the Hugging Face Hub.
   """
@@ -46,20 +53,25 @@ defmodule Tokenizers.Tokenizer do
 
   @doc """
   Encode the given sequence or batch of sequences to a `Tokenizers.Encoding.t()`.
+
+  ## Options
+
+    * `:add_special_tokens` - whether to add special tokens to the encoding
+
   """
-  @spec encode(Tokenizer.t(), String.t() | [String.t()], Keyword.t()) ::
+  @spec encode(Tokenizer.t(), encode_input() | [encode_input()], Keyword.t()) ::
           {:ok, Encoding.t() | [Encoding.t()]} | {:error, term()}
   def encode(tokenizer, input, opts \\ []) do
     add_special_tokens = Keyword.get(opts, :add_special_tokens, false)
     do_encode(tokenizer, input, add_special_tokens)
   end
 
-  defp do_encode(tokenizer, input, add_special_tokens) when is_binary(input) do
-    Native.encode(tokenizer, input, add_special_tokens)
-  end
-
   defp do_encode(tokenizer, input, add_special_tokens) when is_list(input) do
     Native.encode_batch(tokenizer, input, add_special_tokens)
+  end
+
+  defp do_encode(tokenizer, input, add_special_tokens) do
+    Native.encode(tokenizer, input, add_special_tokens)
   end
 
   @doc """

--- a/native/ex_tokenizers/src/encoding.rs
+++ b/native/ex_tokenizers/src/encoding.rs
@@ -41,6 +41,11 @@ pub fn get_attention_mask(encoding: ExTokenizersEncoding) -> Result<Vec<u32>, Ex
 }
 
 #[rustler::nif]
+pub fn get_type_ids(encoding: ExTokenizersEncoding) -> Result<Vec<u32>, ExTokenizersError> {
+    Ok(encoding.resource.0.get_type_ids().to_vec())
+}
+
+#[rustler::nif]
 pub fn n_tokens(encoding: ExTokenizersEncoding) -> Result<usize, ExTokenizersError> {
     Ok(encoding.resource.0.len())
 }

--- a/native/ex_tokenizers/src/lib.rs
+++ b/native/ex_tokenizers/src/lib.rs
@@ -27,6 +27,7 @@ rustler::init!(
         from_file,
         from_pretrained,
         get_attention_mask,
+        get_type_ids,
         get_ids,
         get_model,
         get_model_details,

--- a/native/ex_tokenizers/src/tokenizer.rs
+++ b/native/ex_tokenizers/src/tokenizer.rs
@@ -61,7 +61,7 @@ pub fn encode_batch(
 ) -> Result<Vec<ExTokenizersEncoding>, ExTokenizersError> {
     let inputs = inputs
         .iter()
-        .map(|input| term_to_encode_input(input))
+        .map(term_to_encode_input)
         .collect::<Result<Vec<EncodeInput>, ExTokenizersError>>()?;
     let encodings = tokenizer
         .resource

--- a/native/ex_tokenizers/src/tokenizer.rs
+++ b/native/ex_tokenizers/src/tokenizer.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use rustler::{Term};
+use rustler::Term;
 
-use tokenizers::{Tokenizer, EncodeInput};
+use tokenizers::{EncodeInput, Tokenizer};
 
 use crate::encoding::ExTokenizersEncoding;
 use crate::error::ExTokenizersError;
@@ -80,7 +80,9 @@ fn term_to_encode_input<'a>(term: &'a Term) -> Result<EncodeInput<'a>, ExTokeniz
     } else if let Ok((seq1, seq2)) = term.decode::<(String, String)>() {
         Ok(EncodeInput::Dual(seq1.into(), seq2.into()))
     } else {
-        Err(ExTokenizersError::Other(String::from("input must be either a string or a tuple")))
+        Err(ExTokenizersError::Other(String::from(
+            "input must be either a string or a tuple",
+        )))
     }
 }
 

--- a/test/tokenizers/tokenizer_test.exs
+++ b/test/tokenizers/tokenizer_test.exs
@@ -27,7 +27,7 @@ defmodule Tokenizers.TokenizerTest do
 
   describe "encode/decode" do
     test "can encode a single string", %{tokenizer: tokenizer} do
-      assert match?({:ok, %Tokenizers.Encoding{}}, Tokenizer.encode(tokenizer, "This is a test"))
+      assert {:ok, %Tokenizers.Encoding{}} = Tokenizer.encode(tokenizer, "This is a test")
     end
 
     test "can encode a single string with special characters", %{tokenizer: tokenizer} do
@@ -38,11 +38,18 @@ defmodule Tokenizers.TokenizerTest do
       refute Encoding.n_tokens(encoding_clean) == Encoding.n_tokens(encoding_special)
     end
 
+    test "can encode a pair of strings", %{tokenizer: tokenizer} do
+      assert {:ok, %Tokenizers.Encoding{}} = Tokenizer.encode(tokenizer, {"Question?", "Answer"})
+    end
+
     test "can encode a batch of strings", %{tokenizer: tokenizer} do
-      assert match?(
-               {:ok, [%Tokenizers.Encoding{} | _]},
+      assert {:ok, [%Tokenizers.Encoding{}, %Tokenizers.Encoding{}]} =
                Tokenizer.encode(tokenizer, ["This is a test", "And so is this"])
-             )
+    end
+
+    test "can encode a batch of strings and pairs", %{tokenizer: tokenizer} do
+      assert {:ok, [%Tokenizers.Encoding{}, %Tokenizers.Encoding{}]} =
+               Tokenizer.encode(tokenizer, ["This is a test", {"Question?", "Answer"}])
     end
 
     test "can decode a single encoding", %{tokenizer: tokenizer} do


### PR DESCRIPTION
In certain NLP tasks we want to encode two sentences, this is already supported by tokenizers, this extends the API accordingly.

```elixir
iex> {:ok, tokenizer} = Tokenizers.Tokenizer.from_file("test/fixtures/bert-base-cased.json")       
{:ok,
 #Tokenizers.Tokenizer<[
   vocab_size: 28996,
   continuing_subword_prefix: "##",
   max_input_chars_per_word: 100,
   model_type: "bpe",
   unk_token: "[UNK]"
 ]>}
iex> {:ok, encoding} = Tokenizers.Tokenizer.encode(tokenizer, {"test", "test"}, add_special_tokens: true) 
{:ok, #Tokenizers.Tokenizer<[n_tokens: 5, ids: [101, 2774, 102, 2774, 102]]>}
iex> Tokenizers.Encoding.get_type_ids(encoding)                                                           
[0, 0, 0, 1, 1]
iex> Tokenizers.Encoding.get_tokens(encoding)  
["[CLS]", "test", "[SEP]", "test", "[SEP]"]
```