### PR TITLE
Add libssl-dev to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
         shell: bash
         run: |
           case ${{ matrix.job.target }} in
-            arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf libssl libssh-dev openssl;;
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu libssl libssh-dev openssl;;
+            arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf libssl-dev openssl;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu libssl-dev openssl;;
           esac
 
       - name: Extract crate information


### PR DESCRIPTION
I think this will do it

`libssl-dev` is the Ubuntu version of libssl

Not sure if we need to bump the version or not for the release