### PR TITLE
Fix "cross" configuration for release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-  # pull_request:
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ env:
   ELIXIR_VERSION: 1.13
   OTP_VERSION: 24.2
   MIX_ENV: test
+  TOKENIZERS_BUILD: "true"
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  # pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,9 @@ on:
   push:
     branches:
       - main
-      - ps-fix-precomp-with-openssl
-    # paths:
-    #   # Just run on main branch if "native" path changed. Tags will always run.
-    #   - "native/**"
+    paths:
+      # Just run on main branch if "native" path changed. Tags will always run.
+      - "native/**"
     tags:
       - "*"
 
@@ -36,40 +35,40 @@ jobs:
               use-cross: true,
             }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16", use-cross: true }
-          # - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
-          # - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
-          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
+          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
+          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
           - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.16", use-cross: true }
-          # - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
-          # - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
           # NIF version 2.15
-          # - {
-          #     target: arm-unknown-linux-gnueabihf,
-          #     os: ubuntu-20.04,
-          #     nif: "2.15",
-          #     use-cross: true,
-          #   }
-          # - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
-          # - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
-          # - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
-          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
-          # - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true }
-          # - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
-          # - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
-          # # # NIF version 2.14
-          # - {
-          #     target: arm-unknown-linux-gnueabihf,
-          #     os: ubuntu-20.04,
-          #     nif: "2.14",
-          #     use-cross: true,
-          #   }
-          # - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
-          # - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
-          # - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
-          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
-          # - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true }
-          # - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
-          # - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.15",
+              use-cross: true,
+            }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
+          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
+          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
+          # NIF version 2.14
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.14",
+              use-cross: true,
+            }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
+          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
+          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
 
     env:
       RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
@@ -117,7 +116,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.job.use-cross }}" == "true" ]; then
-            cross build -v --release --target=${{ matrix.job.target }}
+            cross build --release --target=${{ matrix.job.target }}
           else
             cargo build --release --target=${{ matrix.job.target }}
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
     branches:
       - main
       - ps-fix-precomp-with-openssl
-    paths:
-      # Just run on main branch if "native" path changed. Tags will always run.
-      - "native/**"
+    # paths:
+    #   # Just run on main branch if "native" path changed. Tags will always run.
+    #   - "native/**"
     tags:
       - "*"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,13 @@ jobs:
               os: ubuntu-20.04,
               nif: "2.16",
               use-cross: true,
+              features: "static_openssl",
             }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16", use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
           - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.16", use-cross: true }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.16", use-cross: true, features: "static_openssl" }
           - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
           - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
           # NIF version 2.15
@@ -47,12 +48,13 @@ jobs:
               os: ubuntu-20.04,
               nif: "2.15",
               use-cross: true,
+              features: "static_openssl",
             }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
           - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true, features: "static_openssl" }
           - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
           - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
           # NIF version 2.14
@@ -61,12 +63,13 @@ jobs:
               os: ubuntu-20.04,
               nif: "2.14",
               use-cross: true,
+              features: "static_openssl",
             }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
           - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true, features: "static_openssl" }
           - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
           - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
 
@@ -116,9 +119,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.job.use-cross }}" == "true" ]; then
-            cross build --release --target=${{ matrix.job.target }}
+            cross build --release --target=${{ matrix.job.target }} --features=${{ matrix.job.features }}
           else
-            cargo build --release --target=${{ matrix.job.target }}
+            cargo build --release --target=${{ matrix.job.target }} --features=${{ matrix.job.features }}
           fi
 
       - name: Rename lib to the final name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           binary: "cross"
           version: "v0.2.4"
-          download_url: "https://github.com/cross-rs/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+          download_url: "https://github.com/cross-rs/cross/releases/download/${version}/cross-x86_64-unknown-linux-gnu.tar.gz"
           tarball_binary_path: "${binary}"
           smoke_test: "${binary} --version"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,40 +36,40 @@ jobs:
               use-cross: true,
             }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16", use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
-          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
+          # - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
+          # - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
+          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
           - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.16", use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
+          # - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
+          # - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
           # NIF version 2.15
-          - {
-              target: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
-              nif: "2.15",
-              use-cross: true,
-            }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
-          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
-          # # NIF version 2.14
-          - {
-              target: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
-              nif: "2.14",
-              use-cross: true,
-            }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
-          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
+          # - {
+          #     target: arm-unknown-linux-gnueabihf,
+          #     os: ubuntu-20.04,
+          #     nif: "2.15",
+          #     use-cross: true,
+          #   }
+          # - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
+          # - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
+          # - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
+          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
+          # - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true }
+          # - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
+          # - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
+          # # # NIF version 2.14
+          # - {
+          #     target: arm-unknown-linux-gnueabihf,
+          #     os: ubuntu-20.04,
+          #     nif: "2.14",
+          #     use-cross: true,
+          #   }
+          # - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
+          # - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
+          # - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
+          # - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
+          # - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true }
+          # - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
+          # - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
 
     env:
       RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
@@ -117,7 +117,7 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.job.use-cross }}" == "true" ]; then
-            cross build --release --target=${{ matrix.job.target }}
+            cross build -v --release --target=${{ matrix.job.target }}
           else
             cargo build --release --target=${{ matrix.job.target }}
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,6 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
 
-      - name: Install prerequisites
-        shell: bash
-        run: |
-          case ${{ matrix.job.target }} in
-            arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf libssl-dev openssl;;
-            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu libssl-dev openssl;;
-          esac
-
       - name: Extract crate information
         shell: bash
         run: |
@@ -115,8 +107,8 @@ jobs:
         if: ${{ matrix.job.use-cross }}
         with:
           binary: "cross"
-          version: "v0.2.1"
-          download_url: "https://github.com/rust-embedded/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+          version: "v0.2.4"
+          download_url: "https://github.com/cross-rs/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
           tarball_binary_path: "${binary}"
           smoke_test: "${binary} --version"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - ps-fix-precomp-with-openssl
     paths:
       # Just run on main branch if "native" path changed. Tags will always run.
       - "native/**"

--- a/native/ex_tokenizers/Cargo.lock
+++ b/native/ex_tokenizers/Cargo.lock
@@ -400,6 +400,7 @@ name = "ex_tokenizers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "openssl",
  "rustler",
  "thiserror",
  "tokenizers",
@@ -988,6 +989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1006,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/native/ex_tokenizers/Cargo.toml
+++ b/native/ex_tokenizers/Cargo.toml
@@ -9,6 +9,12 @@ name = "ex_tokenizers"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 
+[target.arm-unknown-linux-gnueabihf.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
+[target.x86_64-unknown-linux-musl.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 [dependencies]
 anyhow = "1"
 rustler = "0.25.0"

--- a/native/ex_tokenizers/Cargo.toml
+++ b/native/ex_tokenizers/Cargo.toml
@@ -9,14 +9,12 @@ name = "ex_tokenizers"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 
-[target.arm-unknown-linux-gnueabihf.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
-
-[target.x86_64-unknown-linux-musl.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
-
 [dependencies]
 anyhow = "1"
 rustler = "0.25.0"
 thiserror = "1"
 tokenizers = "0.11.3"
+openssl = { version = "0.10", optional = true }
+
+[features]
+static_openssl = ["openssl/vendored"]

--- a/native/ex_tokenizers/Cross.toml
+++ b/native/ex_tokenizers/Cross.toml
@@ -3,6 +3,7 @@ passthrough = [
   "RUSTLER_NIF_VERSION"
 ]
 
+# We need to install some dependencies for specific targets.
 [target.arm-unknown-linux-gnueabihf]
 pre-build = "./scripts/install-cross-deps"
 

--- a/native/ex_tokenizers/Cross.toml
+++ b/native/ex_tokenizers/Cross.toml
@@ -9,6 +9,3 @@ pre-build = "./scripts/install-cross-deps"
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = "./scripts/install-cross-deps"
-
-[target.x86_64-unknown-linux-musl]
-pre-build = "./scripts/install-cross-deps"

--- a/native/ex_tokenizers/Cross.toml
+++ b/native/ex_tokenizers/Cross.toml
@@ -1,0 +1,13 @@
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]
+
+[target.arm-unknown-linux-gnueabihf]
+pre-build = "./scripts/install-cross-deps"
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = "./scripts/install-cross-deps"
+
+[target.x86_64-unknown-linux-musl]
+pre-build = "./scripts/install-cross-deps"

--- a/native/ex_tokenizers/scripts/install-cross-deps
+++ b/native/ex_tokenizers/scripts/install-cross-deps
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Script to install dependencies for cross compilation
+
+dpkg --add-architecture $CROSS_DEB_ARCH
+
+apt-get update
+apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH openssl:$CROSS_DEB_ARCH


### PR DESCRIPTION
This is going to install the "libssl-dev" along wigh "openssl" in targets that don't have these packages by default.

It also fix a configuration to pass down the "RUSTLER_NIF_VERSION" env variable to containers building with cross.