### PR TITLE
Force NIF compilation in docs workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,7 @@ concurrency:
 env:
   ELIXIR_VERSION: 1.13
   OTP_VERSION: 24.2
+  TOKENIZERS_BUILD: "true"
 
 jobs:
   deploy:


### PR DESCRIPTION
This is because we always want to have compilation in the CI, since we don't have the checksum file in development versions.