### PR TITLE
Release v0.1.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tokenizers.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-nx/tokenizers"
-  @version "0.2.0-dev"
+  @version "0.2.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tokenizers.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-nx/tokenizers"
-  @version "0.2.0"
+  @version "0.1.1"
 
   def project do
     [

--- a/native/ex_tokenizers/Cargo.toml
+++ b/native/ex_tokenizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ex_tokenizers"
-version = "0.1.0"
+version = "0.2.0"
 authors = []
 edition = "2018"
 

--- a/native/ex_tokenizers/Cargo.toml
+++ b/native/ex_tokenizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ex_tokenizers"
-version = "0.2.0"
+version = "0.1.1"
 authors = []
 edition = "2018"
 


### PR DESCRIPTION
Bump versions so we can tag as v0.2 and release with updated precompiled NIFs