### PR TITLE
Add musl to targets

### DIFF
--- a/lib/tokenizers/native.ex
+++ b/lib/tokenizers/native.ex
@@ -8,7 +8,8 @@ defmodule Tokenizers.Native do
     crate: "ex_tokenizers",
     version: version,
     base_url: "#{github_url}/releases/download/v#{version}",
-    force_build: System.get_env("TOKENIZERS_BUILD") in ["1", "true"]
+    force_build: System.get_env("TOKENIZERS_BUILD") in ["1", "true"],
+    targets: RustlerPrecompiled.Config.default_targets() ++ ["aarch64-unknown-linux-musl"]
 
   def decode(_tokenizer, _ids, _skip_special_tokens), do: err()
   def decode_batch(_tokenizer, _ids, _skip_special_tokens), do: err()

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tokenizers.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/elixir-nx/tokenizers"
-  @version "0.1.1"
+  @version "0.1.2"
 
   def project do
     [

--- a/native/ex_tokenizers/Cargo.toml
+++ b/native/ex_tokenizers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ex_tokenizers"
-version = "0.1.1"
+version = "0.1.2"
 authors = []
 edition = "2018"
 


### PR DESCRIPTION
@philss I wonder if `aarch64-unknown-linux-musl` should be included as a rustler precompiled default too? For context I got an error about this missing pre-compiled version of tokenizers when trying to build it into an Elixir Alpine Docker image on a M1 MBP