### PR TITLE
Add support for regular expressions in Tokenizers.PreTokenizer.split/3

### DIFF
--- a/lib/tokenizers/pre_tokenizer.ex
+++ b/lib/tokenizers/pre_tokenizer.ex
@@ -137,17 +137,25 @@ defmodule Tokenizers.PreTokenizer do
   Creates a Split pre-tokenizer.
 
   Versatile pre-tokenizer that splits on provided pattern and according
-  to provided behavior. The pattern can be inverted if necessary.
+  to provided behavior. The pattern can be a string or a regular expression.
+  The pattern can be inverted if necessary.
 
   ## Options
 
     * `:invert` - whether to invert the split or not. Defaults to `false`
 
   """
-  @spec split(String.t(), split_delimiter_behaviour(), keyword()) :: t()
-  defdelegate split(pattern, behavior, opts \\ []),
-    to: Tokenizers.Native,
-    as: :pre_tokenizers_split
+  @spec split(String.t() | Regex.t(), split_delimiter_behaviour(), keyword()) :: t()
+  def split(pattern, behavior, opts \\ [])
+
+  def split(pattern, behavior, opts) when is_binary(pattern) do
+    Tokenizers.Native.pre_tokenizers_split(pattern, behavior, opts)
+  end
+
+  def split(%Regex{} = pattern, behavior, opts) do
+    split(Regex.source(pattern), behavior, Keyword.put(opts, :use_regex, true))
+  end
+
 
   @doc """
   Creates a Punctuation pre-tokenizer.

--- a/lib/tokenizers/pre_tokenizer.ex
+++ b/lib/tokenizers/pre_tokenizer.ex
@@ -137,23 +137,26 @@ defmodule Tokenizers.PreTokenizer do
   Creates a Split pre-tokenizer.
 
   Versatile pre-tokenizer that splits on provided pattern and according
-  to provided behavior. The pattern can be a string or a regular expression.
-  The pattern can be inverted if necessary.
+  to provided behavior. The pattern should be in the form of a tuple
+  `{:string, pattern}` or `{:regex, pattern}` depending on whether the tuple is
+  a regular expression or not. For convenience, a simple binary is accepted
+  as well in which case the pattern is converted to the tuple
+  `{:string, pattern}`.
 
   ## Options
 
     * `:invert` - whether to invert the split or not. Defaults to `false`
 
   """
-  @spec split(String.t() | Regex.t(), split_delimiter_behaviour(), keyword()) :: t()
+  @spec split(String.t() | {:string, String.t()}| {:regex, String.t()} , split_delimiter_behaviour(), keyword()) :: t()
   def split(pattern, behavior, opts \\ [])
 
   def split(pattern, behavior, opts) when is_binary(pattern) do
-    Tokenizers.Native.pre_tokenizers_split(pattern, behavior, opts)
+    split({:string, pattern}, behavior, opts)
   end
 
-  def split(%Regex{} = pattern, behavior, opts) do
-    split(Regex.source(pattern), behavior, Keyword.put(opts, :use_regex, true))
+  def split(pattern, behavior, opts) do
+    Tokenizers.Native.pre_tokenizers_split(pattern, behavior, opts)
   end
 
 

--- a/lib/tokenizers/pre_tokenizer.ex
+++ b/lib/tokenizers/pre_tokenizer.ex
@@ -134,31 +134,44 @@ defmodule Tokenizers.PreTokenizer do
           | :contiguous
 
   @doc """
-  Creates a Split pre-tokenizer.
+  Creates a Split pre-tokenizer using a string as split pattern.
 
   Versatile pre-tokenizer that splits on provided pattern and according
-  to provided behavior. The pattern should be in the form of a tuple
-  `{:string, pattern}` or `{:regex, pattern}` depending on whether the tuple is
-  a regular expression or not. For convenience, a simple binary is accepted
-  as well in which case the pattern is converted to the tuple
-  `{:string, pattern}`.
+  to provided behavior.
 
   ## Options
 
     * `:invert` - whether to invert the split or not. Defaults to `false`
 
   """
-  @spec split(String.t() | {:string, String.t()}| {:regex, String.t()} , split_delimiter_behaviour(), keyword()) :: t()
-  def split(pattern, behavior, opts \\ [])
-
-  def split(pattern, behavior, opts) when is_binary(pattern) do
-    split({:string, pattern}, behavior, opts)
+  @spec split(String.t(), split_delimiter_behaviour(), keyword()) :: t()
+  def split(pattern, behavior, opts \\ []) when is_binary(pattern) do
+    Tokenizers.Native.pre_tokenizers_split({:string, pattern}, behavior, opts)
   end
 
-  def split(pattern, behavior, opts) do
-    Tokenizers.Native.pre_tokenizers_split(pattern, behavior, opts)
-  end
+  @doc ~S"""
+  Creates a Split pre-tokenizer using a regular expression as split pattern.
 
+  Versatile pre-tokenizer that splits on provided regex pattern and according
+  to provided behavior.
+
+  The `pattern` should be a string representing a regular expression
+  according to the [Oniguruma Regex Engine](https://github.com/kkos/oniguruma).
+
+  ## Options
+
+    * `:invert` - whether to invert the split or not. Defaults to `false`
+
+  ## Example
+
+      iex> Tokenizers.PreTokenizer.split_regex(~S(\?\d{2}\?), :removed)
+      #Tokenizers.PreTokenizer<[pre_tokenizer_type: "Split"]>
+
+  """
+  @spec split_regex(String.t(), split_delimiter_behaviour(), keyword()) :: t()
+  def split_regex(pattern, behavior, opts \\ []) when is_binary(pattern) do
+    Tokenizers.Native.pre_tokenizers_split({:regex, pattern}, behavior, opts)
+  end
 
   @doc """
   Creates a Punctuation pre-tokenizer.

--- a/native/ex_tokenizers/src/pre_tokenizers.rs
+++ b/native/ex_tokenizers/src/pre_tokenizers.rs
@@ -2,8 +2,8 @@ use crate::util::Info;
 use crate::{new_info, ExTokenizersError};
 use rustler::NifTaggedEnum;
 use serde::{Deserialize, Serialize};
-use tokenizers::PreTokenizer;
 use tokenizers::pre_tokenizers::split::SplitPattern;
+use tokenizers::PreTokenizer;
 use tokenizers::{processors::byte_level::ByteLevel, PreTokenizedString, PreTokenizerWrapper};
 
 pub struct ExTokenizersPreTokenizerRef(pub PreTokenizerWrapper);
@@ -245,7 +245,7 @@ pub enum SplitOption {
 #[derive(NifTaggedEnum)]
 pub enum LocalSplitPattern {
     String(String),
-    Regex(String)
+    Regex(String),
 }
 
 #[rustler::nif]

--- a/native/ex_tokenizers/src/pre_tokenizers.rs
+++ b/native/ex_tokenizers/src/pre_tokenizers.rs
@@ -240,12 +240,17 @@ impl From<SplitDelimiterBehavior> for tokenizers::SplitDelimiterBehavior {
 #[derive(NifTaggedEnum)]
 pub enum SplitOption {
     Invert(bool),
-    UseRegex(bool)
+}
+
+#[derive(NifTaggedEnum)]
+pub enum LocalSplitPattern {
+    String(String),
+    Regex(String)
 }
 
 #[rustler::nif]
 pub fn pre_tokenizers_split(
-    pattern: String,
+    pattern: LocalSplitPattern,
     behavior: SplitDelimiterBehavior,
     options: Vec<SplitOption>,
 ) -> Result<ExTokenizersPreTokenizer, rustler::Error> {
@@ -253,12 +258,14 @@ pub fn pre_tokenizers_split(
         invert: bool,
     }
     let mut opts = Opts { invert: false };
-    let mut final_pattern = SplitPattern::String(String::from(""));
+    let final_pattern = match pattern {
+        LocalSplitPattern::String(pattern) => SplitPattern::String(pattern),
+        LocalSplitPattern::Regex(pattern) => SplitPattern::Regex(pattern),
+    };
+
     for option in options {
         match option {
             SplitOption::Invert(invert) => opts.invert = invert,
-            SplitOption::UseRegex(true) => final_pattern = SplitPattern::Regex(pattern.to_owned()),
-            SplitOption::UseRegex(false) => final_pattern = SplitPattern::String(pattern.to_owned()),
         }
     }
 

--- a/test/tokenizers/pre_tokenizer_test.exs
+++ b/test/tokenizers/pre_tokenizer_test.exs
@@ -22,6 +22,11 @@ defmodule Tokenizers.PreTokenizerTest do
       assert %Tokenizers.PreTokenizer{} =
                Tokenizers.PreTokenizer.split(" ", :removed, invert: true)
     end
+
+    test "accepts regular expressions" do
+      assert %Tokenizers.PreTokenizer{} =
+               Tokenizers.PreTokenizer.split(~r/.*/, :removed)
+    end
   end
 
   describe "WhitespaceSplit pretokenizer" do

--- a/test/tokenizers/pre_tokenizer_test.exs
+++ b/test/tokenizers/pre_tokenizer_test.exs
@@ -15,21 +15,24 @@ defmodule Tokenizers.PreTokenizerTest do
 
   describe "Split pretokenizer" do
     test "accepts no parameters" do
-      assert %Tokenizers.PreTokenizer{} = Tokenizers.PreTokenizer.split({:string, " "}, :removed)
-    end
-
-    test "accepts regular expressions" do
-      assert %Tokenizers.PreTokenizer{} =
-               Tokenizers.PreTokenizer.split({:regex, ~S/.*/}, :removed)
-    end
-
-    test "accepts binaries" do
       assert %Tokenizers.PreTokenizer{} = Tokenizers.PreTokenizer.split(" ", :removed)
     end
 
     test "accepts options" do
       assert %Tokenizers.PreTokenizer{} =
                Tokenizers.PreTokenizer.split(" ", :removed, invert: true)
+    end
+  end
+
+  describe "Regex split pretokenizer" do
+    test "accepts regular expressions" do
+      assert %Tokenizers.PreTokenizer{} =
+               Tokenizers.PreTokenizer.split_regex(".*", :removed)
+    end
+
+    test "accepts options" do
+      assert %Tokenizers.PreTokenizer{} =
+               Tokenizers.PreTokenizer.split_regex(".*", :removed, invert: true)
     end
   end
 

--- a/test/tokenizers/pre_tokenizer_test.exs
+++ b/test/tokenizers/pre_tokenizer_test.exs
@@ -15,17 +15,21 @@ defmodule Tokenizers.PreTokenizerTest do
 
   describe "Split pretokenizer" do
     test "accepts no parameters" do
+      assert %Tokenizers.PreTokenizer{} = Tokenizers.PreTokenizer.split({:string, " "}, :removed)
+    end
+
+    test "accepts regular expressions" do
+      assert %Tokenizers.PreTokenizer{} =
+               Tokenizers.PreTokenizer.split({:regex, ~S/.*/}, :removed)
+    end
+
+    test "accepts binaries" do
       assert %Tokenizers.PreTokenizer{} = Tokenizers.PreTokenizer.split(" ", :removed)
     end
 
     test "accepts options" do
       assert %Tokenizers.PreTokenizer{} =
                Tokenizers.PreTokenizer.split(" ", :removed, invert: true)
-    end
-
-    test "accepts regular expressions" do
-      assert %Tokenizers.PreTokenizer{} =
-               Tokenizers.PreTokenizer.split(~r/.*/, :removed)
     end
   end
 


### PR DESCRIPTION
Hey,

This is a proposal for supporting regular expressions as `pattern` in Tokenizers.PreTokenizer.split/3 as discussed in #53. As I already mentioned in #53, I'm not a Rust developer so while I could successfully test my changes, I'm not sure this code is "good to go". What do you think?

Thanks,
Michael