### PR TITLE
add support for regular expressions in `Tokenizers.Normalizer.replace/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support for regular expressions to replace normalizer. See
+  `Tokenizers.Normalizer.replace_regex/2`.
+- Support for regular expressions to split pre-tokenizer. See
+  `Tokenizers.PreTokenizer.split_regex/3`.
+
 ## [v0.4.0] - 2023-08-09
 
 ### Added

--- a/lib/tokenizers/normalizer.ex
+++ b/lib/tokenizers/normalizer.ex
@@ -117,12 +117,23 @@ defmodule Tokenizers.Normalizer do
   defdelegate lowercase(), to: Tokenizers.Native, as: :normalizers_lowercase
 
   @doc """
-  Replaces a custom string or regexp and changes it with given content.
+  Replaces a custom `search` string with the given `content`.
   """
   @spec replace(String.t(), String.t()) :: t()
-  defdelegate replace(pattern, content),
-    to: Tokenizers.Native,
-    as: :normalizers_replace
+  def replace(search, content) do
+    Tokenizers.Native.normalizers_replace({:string, search}, content)
+  end
+
+  @doc """
+  Replaces occurrences of a custom regexp `pattern` with the given `content`.
+
+  The `pattern` should be a string representing a regular expression
+  according to the [Oniguruma Regex Engine](https://github.com/kkos/oniguruma).
+  """
+  @spec replace_regex(String.t(), String.t()) :: t()
+  def replace_regex(pattern, content) do
+    Tokenizers.Native.normalizers_replace({:regex, pattern}, content)
+  end
 
   @doc """
   Creates a Nmt normalizer.

--- a/test/tokenizers/normalizer_test.exs
+++ b/test/tokenizers/normalizer_test.exs
@@ -90,4 +90,28 @@ defmodule Tokenizers.NormalizerTest do
                {:ok, "▁Hello"}
     end
   end
+
+  describe "Replace" do
+    test "can be initialized" do
+      assert %Tokenizers.Normalizer{} = Tokenizers.Normalizer.replace("find", "replace")
+    end
+
+    test "can normalize strings" do
+      assert Tokenizers.Normalizer.replace("Hello", "World")
+             |> Tokenizers.Normalizer.normalize("Hello") ==
+               {:ok, "World"}
+    end
+  end
+
+  describe "Replace Regex" do
+    test "can be initialized" do
+      assert %Tokenizers.Normalizer{} = Tokenizers.Normalizer.replace_regex("\\d*", "")
+    end
+
+    test "can normalize strings" do
+      assert Tokenizers.Normalizer.replace_regex("\\d*", "")
+             |> Tokenizers.Normalizer.normalize("1Hel2lo3") ==
+               {:ok, "Hello"}
+    end
+  end
 end


### PR DESCRIPTION
Very similar to my last PR #54. This adds regex support to `Tokenizers.Normalizer.replace/2` via `Tokenizers.Normalizer.replace_regex/2`.

* Added `Tokenizers.Normalizer.replace_regex/2`
* Added changelogs (also for #54)
* Added tests for both `Tokenizers.Normalizer.replace/2` and `Tokenizers.Normalizer.replace_regex/2`.

BTW: Would be nice to get a release with these two additions once merged. ❤️